### PR TITLE
Change order of function declaration in VarScheduler

### DIFF
--- a/src/smtrat-modules/SATModule/VarScheduler.h
+++ b/src/smtrat-modules/SATModule/VarScheduler.h
@@ -175,13 +175,6 @@ namespace smtrat
     class VarSchedulerFixedRandom : public VarSchedulerMinisat {
         std::vector<Minisat::Var> ordering;
 
-    public:
-
-        template<typename BaseModule>
-        explicit VarSchedulerFixedRandom( BaseModule& baseModule ) :
-            VarSchedulerMinisat( baseModule, [this](Minisat::Var x, Minisat::Var y) -> bool { return getIndex(x) > getIndex(y); } )
-        {} 
-
     private:
 
         auto getIndex(Minisat::Var var) {
@@ -200,6 +193,15 @@ namespace smtrat
             }
             return iter;
         }
+        
+    public:
+
+        template<typename BaseModule>
+        explicit VarSchedulerFixedRandom( BaseModule& baseModule ) :
+            VarSchedulerMinisat( baseModule, [this](Minisat::Var x, Minisat::Var y) -> bool { return getIndex(x) > getIndex(y); } )
+        {} 
+
+    
     };
 
     /**


### PR DESCRIPTION
getIndex cannot be used before defined using clang++ from homebrew on Mac.